### PR TITLE
Adblock Plus, AdBlock 지원 및 주의사항 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@
     - **Adguard**
     - **uBlock Origin**
     - **Personal Blocklist(not by Google)**
+    - **Adblock Plus**
+    - **AdBlock**
 
-- 테스트되지 않은 플러그인
-    - Adblock Plus
+- Adblock Plus, AdBlock 사용시 주의사항
+    - (Adblock Plus) "허용되는 광고"를 허용하거나 (AdBlock) "허용할만한 광고" 필터를 구독하면 google.com에서 모든 필터가 적용되지 않습니다. 이를 해제해야 합니다.
 
 ## [차단하는 사이트 목록](hosts.txt)
 

--- a/only-stackoverflow.tmpl
+++ b/only-stackoverflow.tmpl
@@ -6,5 +6,5 @@
 ! Expires: 4 days
 ! Version: {version}
 
-google.com#?#div[role="main"] div#search div[data-async-context] div[data-ved]:contains(/{regex}/)
-duckduckgo.com#?#div.result:contains(/{regex}/)
+google.com#?#div[role="main"] div#search div[data-async-context] div[data-ved]:-abp-contains(/{regex}/)
+duckduckgo.com#?#div.result:-abp-contains(/{regex}/)


### PR DESCRIPTION
https://help.eyeo.com/en/adblockplus/how-to-write-filters#elemhide-emulation

Adblock Plus-specific한 Extended CSS selectors를 사용하도록 변경하여 Adblock Plus와 AdBlock을 지원합니다.