### PR TITLE
Fix url-encode issue on filter subscription link

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -1,6 +1,6 @@
 # only-stackoverflow
 
-[![Subscribe filter](https://img.shields.io/badge/Subscribe%20Filter-Adblock%20Plus-brightgreen?logo=adblockplus)](https://subscribe.adblockplus.org/?location=https%3A%2F%2Fgithub.com%2FRyuaNerin%2Fonly-stackoverflow%2Fraw%2Fmaster%2Fonly-stackoverflow.txt%26title%3Donly-stackoverflow)
+[![Subscribe filter](https://img.shields.io/badge/Subscribe%20Filter-Adblock%20Plus-brightgreen?logo=adblockplus)](https://subscribe.adblockplus.org/?location=https://github.com/RyuaNerin/only-stackoverflow/raw/master/only-stackoverflow.txt&title=only-stackoverflow)
 
 ![banner](banner.png)
 
@@ -15,7 +15,7 @@
         - [`build.bash`](build.bash)
         - [`hosts.txt`](hosts.txt)
 
-## [Subscribe only-stackoverflow filter](https://subscribe.adblockplus.org/?location=https%3A%2F%2Fgithub.com%2FRyuaNerin%2Fonly-stackoverflow%2Fraw%2Fmaster%2Fonly-stackoverflow.txt%26title%3Donly-stackoverflow)
+## [Subscribe only-stackoverflow filter](https://subscribe.adblockplus.org/?location=https://github.com/RyuaNerin/only-stackoverflow/raw/master/only-stackoverflow.txt&title=only-stackoverflow)
 
 - **Tested plugins**
     - **Adguard**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # only-stackoverflow
 
-[![필터 구독하기](https://img.shields.io/badge/Subscribe%20Filter-Adblock%20Plus-brightgreen?logo=adblockplus)](https://subscribe.adblockplus.org/?location=https%3A%2F%2Fgithub.com%2FRyuaNerin%2Fonly-stackoverflow%2Fraw%2Fmaster%2Fonly-stackoverflow.txt%26title%3Donly-stackoverflow)
+[![필터 구독하기](https://img.shields.io/badge/Subscribe%20Filter-Adblock%20Plus-brightgreen?logo=adblockplus)](https://subscribe.adblockplus.org/?location=https://github.com/RyuaNerin/only-stackoverflow/raw/master/only-stackoverflow.txt&title=only-stackoverflow)
 
 ![banner](banner.png)
 


### PR DESCRIPTION
- Related PR: #47

Apply same fix on badge link + english readme

Have tested on macOS + chrome + AdGuard chrome extension.

(For me, even before fix url, link worked)