### PR TITLE
Add `adoclib.com`

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -100,3 +100,4 @@ wekeepcoding.com
 wikiqube.net
 xspdf.com
 202psj.tistory.com
+adoclib.com


### PR DESCRIPTION
- Original: https://stackoverflow.com/questions/31122193/how-do-i-install-the-babel-polyfill-library
- Copy (and mixed up nearly everything): https://www.adoclib.com/blog/how-to-get-property-bind-of-undefined-babel-7-core-js-ie11.html

```markdown
# matched line
Usage in Node / Browserify / Webpack. To include the polyfill you need to require it at the top of the entry point to your application. Make sure it is called.
```

Everything of this site is just a hoax. (ex. https://www.adoclib.com/purchase/dotnet-pdf.html)