### PR TITLE
codebug.zone 추가

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -118,3 +118,5 @@ wepython.cc
 wikiqube.net
 xspdf.com
 202psj.tistory.com
+codebug.zone
+*.codebug.zone


### PR DESCRIPTION
Issue #65 (가능하면 링크해주세요)

*.codebug.zone은 언어따라 서브도메인 만들어진거같고
codebug.zone 자체도 스택오버플로를 중국어로 번역한거같아서 같이 넣었습니다.