### PR TITLE
add: SOF copy hosts

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -145,3 +145,8 @@ wikiqube.net
 xspdf.com
 yingqusp.com
 202psj.tistory.com
+dtuto.com
+appsloveworld.com
+ittutorialpoint.com
+angularfixing.com
+so.muouseo.com


### PR DESCRIPTION
원본: https://stackoverflow.com/questions/71336975/npm-error-transpiledependencies-map-is-not-a-function

카피본
1. https://so.muouseo.com/qa/rpk6pdr2r63z.html
2. https://angularfixing.com/npm-error-transpiledependencies-map-is-not-a-function/
3. https://www.appsloveworld.com/vuejs/100/21/npm-error-transpiledependencies-map-is-not-a-function
4. https://dtuto.com/questions/9949/npm-error-transpiledependencies-map-is-not-a-function
5. https://solveforum.com/forums/threads/solved-npm-error-transpiledependencies-map-is-not-a-function.628048/ 